### PR TITLE
Remove activesupport version restriction and bump version to 1.0.0

### DIFF
--- a/lib/settings-in-redis/version.rb
+++ b/lib/settings-in-redis/version.rb
@@ -1,3 +1,3 @@
 module SettingsInRedis
-  VERSION = '0.0.1'
+  VERSION = '1.0.0'
 end

--- a/settings-in-redis.gemspec
+++ b/settings-in-redis.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency 'redis'
-  s.add_runtime_dependency 'activesupport', '~> 3.1.12'
+  s.add_runtime_dependency 'activesupport'
   s.add_runtime_dependency 'i18n' # required by activesupport
 
   s.add_development_dependency 'rake'


### PR DESCRIPTION
The activesupport version restriction causes a problem now that all the apps are on 3.2.x.

Bump the version to 1.0.0 since this will be used in the Imap app.
