### PR TITLE
fix: Allow ActiveSupport::HashWithIndifferentAccess object to be deserialized

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Gemfile.lock
 pkg/*
 coverage
+.vscode

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,9 +1,15 @@
 ### History of settings-in-redis
 
+Version 1.3.1 (2025-07-11)
+
+- `ActiveSupport::HashWithIndifferentAccess` added to the classes that are allowed to load
+
 Version 1.3.0 (2025-07-08)
+
 - Update to Ruby 3.3
 
 Version 1.2.0 (2023-04-03)
+
 - Update to Ruby 3
 
 Version 1.1.0 (2021-02-05)
@@ -13,7 +19,6 @@ Version 1.1.0 (2021-02-05)
 Version 1.0.0 (2013-10-17)
 
 - Initial release using Redis
-
 
 ### History of ledermann-rails-settings
 

--- a/lib/settings-in-redis/settings.rb
+++ b/lib/settings-in-redis/settings.rb
@@ -73,7 +73,7 @@ module Settings
   def self.redis_key(var_name)
     "#{redis_prefix}:#{var_name}"
   end
-  
+
   # get or set a variable with the variable as the called method
   def self.method_missing(method, *args)
     if self.respond_to?(method)
@@ -84,20 +84,18 @@ module Settings
       # :nocov:
     else
       method_name = method.to_s
-    
       # set a value for a variable
       if method_name =~ /=$/
         var_name = method_name.gsub('=', '')
         value = args.first
         self[var_name] = value
-    
       #retrieve a value
       else
         self[method_name]
       end
     end
   end
-  
+
   # destroy the specified setting
   def self.destroy(var_name)
     var_name = var_name.to_s
@@ -132,7 +130,7 @@ module Settings
       end
     end
   end
-  
+
   # get a setting value by [] notation
   def self.[](var_name)
     cache.fetch(cache_key(var_name), cache_options) do
@@ -146,7 +144,7 @@ module Settings
       end
     end
   end
-  
+
   # set a setting value by [] notation
   def self.[]=(var_name, value)
     redis do |redis_conn|
@@ -160,13 +158,13 @@ module Settings
   # @return [Hash]
   def self.merge!(var_name, hash_value)
     raise ArgumentError unless hash_value.is_a?(Hash)
-    
+
     old_value = self[var_name] || {}
     raise TypeError, "Existing value is not a hash, can't merge!" unless old_value.is_a?(Hash)
-    
+
     new_value = old_value.merge(hash_value)
     self[var_name] = new_value if new_value != old_value
-    
+
     new_value
   end
 
@@ -174,12 +172,12 @@ module Settings
   def self.deserialize(value)
     YAML::safe_load(
       value, permitted_classes: [
-        Symbol, Set, Date, Time, ActiveSupport::TimeWithZone, ActiveSupport::TimeZone, ActiveSupport::Duration
+        Symbol, Set, Date, Time, ActiveSupport::TimeWithZone, ActiveSupport::TimeZone, ActiveSupport::Duration, ActiveSupport::HashWithIndifferentAccess
       ]
     )
   end
   private_class_method :deserialize
-  
+
   # YAML encode value
   def self.serialize(value)
     value.to_yaml

--- a/lib/settings-in-redis/version.rb
+++ b/lib/settings-in-redis/version.rb
@@ -1,3 +1,3 @@
 module SettingsInRedis
-  VERSION = '1.3.0'
+  VERSION = '1.3.1'
 end


### PR DESCRIPTION
In backend I'm getting `Psych::DisallowedClass: Tried to load unspecified class: ActiveSupport::HashWithIndifferentAccess` when settings-in-redis is trying to deserialize something https://cloudlogging.app.goo.gl/vmMPRUoZE66YuX7SA

<img width="1268" height="606" alt="Screenshot 2025-07-11 at 12 31 44 PM" src="https://github.com/user-attachments/assets/2db8f6f1-cca3-45c7-bdc9-c77656a0c16e" />

@faustus7 @kwong-yw 

[KAT-1179]


[KAT-1179]: https://vendasta.jira.com/browse/KAT-1179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ